### PR TITLE
Obtain a list of weekends

### DIFF
--- a/src/__test__/holidayService.test.js
+++ b/src/__test__/holidayService.test.js
@@ -1,0 +1,88 @@
+import { getDates, addDays, isWeekend } from '../holidayService';
+
+describe('holidayService', () => {
+  describe('getDates', () => {
+    it('returns all dates from start to end inclusively', () => {
+      const dates = getDates('2020-01-01', '2020-01-05');
+
+      expect(dates).toEqual([
+        new Date('2020-01-01'),
+        new Date('2020-01-02'),
+        new Date('2020-01-03'),
+        new Date('2020-01-04'),
+        new Date('2020-01-05')
+      ]);
+    });
+
+    it('handles dates spanning over different months', () => {
+      const dates = getDates('2020-01-30', '2020-02-02');
+
+      expect(dates).toEqual([
+        new Date('2020-01-30'),
+        new Date('2020-01-31'),
+        new Date('2020-02-01'),
+        new Date('2020-02-02')
+      ]);
+    });
+
+    it('handles dates spanning over different years', () => {
+      const dates = getDates('2019-12-31', '2020-01-02');
+
+      expect(dates).toEqual([
+        new Date('2019-12-31'),
+        new Date('2020-01-01'),
+        new Date('2020-01-02')
+      ]);
+    });
+  });
+
+  describe('addDays', () => {
+    it('can increment a day', () => {
+      const date = new Date('2019-12-24');
+      const nextDay = addDays(date, 1);
+
+      expect(nextDay).toEqual(new Date('2019-12-25'));
+    });
+
+    it('can increment multiple days', () => {
+      const date = new Date('2019-12-24');
+      const threeDaysLater = addDays(date, 3);
+
+      expect(threeDaysLater).toEqual(new Date('2019-12-27'));
+    });
+
+    it('can handle change of month', () => {
+      const date = new Date('2020-01-31');
+      const nextDay = addDays(date, 1);
+
+      expect(nextDay).toEqual(new Date('2020-02-01'));
+    });
+
+    it('can handle change of year', () => {
+      const date = new Date('2019-12-31');
+      const nextDay = addDays(date, 1);
+
+      expect(nextDay).toEqual(new Date('2020-01-01'));
+    });
+  });
+
+  describe('isWeekend', () => {
+    it('counts Saturday as a weekend', () => {
+      const date = new Date('2019-12-28');
+
+      expect(isWeekend(date)).toBe(true);
+    });
+
+    it('counts Sunday as a weekend', () => {
+      const date = new Date('2020-03-15');
+
+      expect(isWeekend(date)).toBe(true);
+    });
+
+    it('does not count a weekday as a weekend', () => {
+      const date = new Date('2020-01-01');
+
+      expect(isWeekend(date)).toBe(false);
+    });
+  });
+});

--- a/src/holidayService.js
+++ b/src/holidayService.js
@@ -1,0 +1,21 @@
+export const getDates = (rangeStartDateIso, rangeEndDateIso) => {
+  const endDate = new Date(rangeEndDateIso);
+  let currentDate = new Date(rangeStartDateIso);
+
+  const dates = [];
+
+  while (currentDate <= endDate) {
+    dates.push(currentDate);
+    currentDate = addDays(currentDate, 1);
+  }
+
+  return dates;
+};
+
+export const addDays = (date, days) => {
+  const newDate = new Date(date);
+  newDate.setDate(newDate.getDate() + days);
+  return newDate;
+};
+
+export const isWeekend = date => date.getDay() === 6 || date.getDay() === 0;


### PR DESCRIPTION
For Story [ch16].

As we have not yet established how we'll store the dates to calculate the holiday suggestions effectively, for now I've just created functions to return us a range of dates and check if the date is a weekend. It should be fairly easy for us to obtain a list of weekends from a range of date by iterating through them as we perform the checks.

Future consideration - we may end up creating a custom Date type to act as a wrapper around the native javascript Date prototype to improve on the API style and add more custom logic we need for our problem. (e.g. `date.addDays(1)` or `date.isWeekend()` are easier to use and read than `addDays(date, 1)` or `isWeekend(date)`.