### PR TITLE
Add script to enable Google AdSense

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
+    <script data-ad-client="ca-pub-1534839599145038" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+
     <title>홀라밸 🏝</title>
   </head>
   <body>


### PR DESCRIPTION
[ch56] Looks like there will be a follow up step that will only become available in the Google AdSense platform after we add this script to the production deployment 🙂